### PR TITLE
Fix: move escaped quote outside dispatched command

### DIFF
--- a/.config/waybar/modules.jsonc
+++ b/.config/waybar/modules.jsonc
@@ -1,8 +1,8 @@
 {
     "hyprland/workspaces": {
         "format": "{icon}",
-        "on-scroll-down": "hyprctl dispatch \"hl.dsp.focus({workspace = 'e+1'}\")",
-        "on-scroll-up":   "hyprctl dispatch \"hl.dsp.focus({workspace = 'e-1'}\")",
+        "on-scroll-down": "hyprctl dispatch \"hl.dsp.focus({workspace = 'e+1'})\"",
+        "on-scroll-up":   "hyprctl dispatch \"hl.dsp.focus({workspace = 'e-1'})\"",
         "persistent-workspaces": { "*": 5 },
         "cursor": true,
         "format-icons": {


### PR DESCRIPTION

## What
Fixes mouse scrolling on the waybar's workspace module

## Why
The escaped double quote was inside the dispatched function
```
line 1: syntax error near unexpected token `)'
line 1: `hyprctl dispatch "hl.dsp.focus({workspace = 'e+1'}")'
```

## How
Moved the culprit chars in the right place
